### PR TITLE
Ignore file-type in Dependabot to prevent repeated failures

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,11 @@ updates:
   schedule:
     interval: daily
   open-pull-requests-limit: 10
+  ignore:
+    # file-type vulnerability is via oslllo-svg2 > jimp > @jimp/core > file-type
+    # Cannot be fixed until upstream jimp updates to file-type >= 21.3.1
+    # Practical risk is low (only affects ASF parsing, this tool processes SVG/PNG)
+    - dependency-name: "file-type"
 - package-ecosystem: "github-actions"
   directory: "/"
   schedule:


### PR DESCRIPTION
## Summary
- `file-type` の脆弱性は `oslllo-svg2 > jimp > @jimp/core > file-type` の推移的依存で、上流が対応するまで解決不可能
- Dependabotが毎日リトライして `security_update_not_possible` で失敗し続けていた
- `file-type` を ignore に追加して他の依存更新PRがブロックされないようにする

## Test plan
- [ ] マージ後、Dependabot Updatesの失敗が解消されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)