### PR TITLE
Update actions/checkout v4 → v6

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Setup Node.js
       uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary
- `actions/checkout` を v4 → v6 に更新（test.yml, release.yml）
- `actions/setup-node` は v4 が最新のため変更なし

## Test plan
- [x] CI でテスト通過を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)