### PR TITLE
Fix publish warnings: explicit bin field, update setup-node v6

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '22.x'
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
     - uses: actions/checkout@v6
 
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: '22.x'
         cache: 'npm'

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "engines": {
     "node": ">=20"
   },
-  "bin": "./generate-icons",
+  "bin": {
+    "generate-icons": "generate-icons"
+  },
   "files": [
     "dist",
     "generate-icons"


### PR DESCRIPTION
## Summary
v0.1.13のリリースActionで出ていた2つの警告を修正:
- `"bin": "./generate-icons"` の省略形を明示的なオブジェクト形式に変更（npm publish警告）
- `actions/setup-node` を v4 → v6 に更新（Node.js 20非推奨警告）

## Test plan
- [x] CI でテスト通過を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)