### PR TITLE
Add required version field to dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,4 @@
+version: 2
 updates:
 - package-ecosystem: npm
   directory: "/"


### PR DESCRIPTION
## Summary
`dependabot.yml` に必須の `version: 2` が欠けていたため、Dependabotのconfig parseが失敗していた。

## Test plan
- [ ] マージ後、Dependabotのparse errorが解消されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)