### PR TITLE
Bump minimum Node.js version from 20 to 22

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,7 +63,7 @@ Test data is stored in `test-data/` directory.
 
 ## Important Implementation Details
 
-1. **Node.js Requirement**: Requires Node.js >= 20
+1. **Node.js Requirement**: Requires Node.js >= 22
 2. **SVG to Raster Conversion**: Uses `oslllo-svg2` library which requires careful size specification
 3. **ICO Format**: ICO files can contain multiple PNG images of different sizes (16x16, 32x32, 48x48, etc.)
 4. **Background Handling**: Default is transparent; optional background color can be specified

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.14",
   "description": "generate icons from single image file",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "bin": {
     "generate-icons": "generate-icons"
@@ -15,7 +15,7 @@
   "scripts": {
     "start": "node ./generate-icons",
     "prepare": "npm run build",
-    "build": "rm -f dist/* && tsc",
+    "build": "rm -rf dist/* && tsc",
     "postversion": "git push && git push --tags",
     "test": "vitest run"
   },


### PR DESCRIPTION
## Summary
- Bump minimum Node.js version from 20 to 22 (Node.js 20 EOL: April 2026)
- Fix build script to use `rm -rf` instead of `rm -f` to properly clean subdirectories in dist/

## Test plan
- [x] `npm test` passes
- [x] `npm run build` succeeds
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)