### PR TITLE
Migrate to ESM

### DIFF
--- a/generate-icons
+++ b/generate-icons
@@ -1,2 +1,2 @@
 #!/usr/bin/env node
-require('./dist/main.js')
+import './dist/main.js'

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "url": "https://github.com/koizuka/generate-icons/issues"
   },
   "homepage": "https://github.com/koizuka/generate-icons#readme",
+  "type": "module",
   "keywords": [
     "svg",
     "ico",

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,9 +2,12 @@ import commandLineArgs from 'command-line-args';
 import commandLineUsage from 'command-line-usage';
 import { readFileSync, writeFileSync } from 'fs';
 import path from 'path';
+import { fileURLToPath } from 'url';
 import { FatalError } from "./FatalError.js";
 import { getConverter } from './getConverter.js';
 import { loadIconsFromManifestJson } from "./loadIconsFromManifestJson.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export function getVersion() {
   const packageJson = readFileSync(path.join(__dirname, '..', 'package.json'));

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,13 +3,12 @@
   "exclude": ["node_modules", "**/*.test.ts"],
   "compilerOptions": {
     "target": "ES2022",
-    "module": "node16",
-    "moduleResolution": "node16",
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
     "outDir": "./dist",
     "rootDir": "./src",
     "types": ["vitest/globals"],
     "strict": true,
-    "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true
   }


### PR DESCRIPTION
## Summary
- Add `"type": "module"` to package.json for native ESM
- Update tsconfig `module`/`moduleResolution` from `node16` to `nodenext`
- Replace `__dirname` with `import.meta.url` + `fileURLToPath`
- Update CLI entry point from `require()` to `import`
- Remove `esModuleInterop` (unnecessary with native ESM)

## Test plan
- [x] `npm test` passes
- [x] `npm run build` succeeds
- [x] `./generate-icons --version` works
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)