### PR TITLE
Replace oxlint with Biome

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,5 +1,3 @@
 {
-  "recommendations": [
-    "oxc.oxc-vscode"
-  ]
+	"recommendations": ["biomejs.biome"]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,11 +1,9 @@
 {
-  "cSpell.words": [
-    "oslllo",
-    "oxlint",
-    "pngjs"
-  ],
-  "oxc.enable": true,
-  "editor.codeActionsOnSave": {
-    "source.fixAll.oxc": "explicit"
-  }
+	"cSpell.words": ["oslllo", "pngjs"],
+	"editor.defaultFormatter": "biomejs.biome",
+	"editor.formatOnSave": true,
+	"editor.codeActionsOnSave": {
+		"source.fixAll.biome": "explicit",
+		"source.organizeImports.biome": "explicit"
+	}
 }

--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,34 @@
+{
+	"$schema": "https://biomejs.dev/schemas/2.4.9/schema.json",
+	"vcs": {
+		"enabled": true,
+		"clientKind": "git",
+		"useIgnoreFile": true
+	},
+	"files": {
+		"includes": ["**", "!!**/dist"]
+	},
+	"formatter": {
+		"enabled": true,
+		"indentStyle": "tab"
+	},
+	"linter": {
+		"enabled": true,
+		"rules": {
+			"recommended": true
+		}
+	},
+	"javascript": {
+		"formatter": {
+			"quoteStyle": "double"
+		}
+	},
+	"assist": {
+		"enabled": true,
+		"actions": {
+			"source": {
+				"organizeImports": "on"
+			}
+		}
+	}
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,18 +18,193 @@
         "generate-icons": "generate-icons"
       },
       "devDependencies": {
+        "@biomejs/biome": "2.4.9",
         "@types/command-line-args": "^5.2.3",
         "@types/command-line-usage": "^5.0.4",
         "@types/node": "^25.5.0",
         "@types/pngjs": "^6.0.5",
         "image-size": "^2.0.2",
-        "oxlint": "^1.57.0",
         "pngjs": "^7.0.0",
         "typescript": "^6.0.2",
         "vitest": "^4.1.1"
       },
       "engines": {
         "node": ">=22"
+      }
+    },
+    "node_modules/@biomejs/biome": {
+      "version": "2.4.9",
+      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.4.9.tgz",
+      "integrity": "sha512-wvZW92FrwitTcacvCBT8xdAbfbxWfDLwjYMmU3djjqQTh7Ni4ZdiWIT/x5VcZ+RQuxiKzIOzi5D+dcyJDFZMsA==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "bin": {
+        "biome": "bin/biome"
+      },
+      "engines": {
+        "node": ">=14.21.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/biome"
+      },
+      "optionalDependencies": {
+        "@biomejs/cli-darwin-arm64": "2.4.9",
+        "@biomejs/cli-darwin-x64": "2.4.9",
+        "@biomejs/cli-linux-arm64": "2.4.9",
+        "@biomejs/cli-linux-arm64-musl": "2.4.9",
+        "@biomejs/cli-linux-x64": "2.4.9",
+        "@biomejs/cli-linux-x64-musl": "2.4.9",
+        "@biomejs/cli-win32-arm64": "2.4.9",
+        "@biomejs/cli-win32-x64": "2.4.9"
+      }
+    },
+    "node_modules/@biomejs/cli-darwin-arm64": {
+      "version": "2.4.9",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.4.9.tgz",
+      "integrity": "sha512-d5G8Gf2RpH5pYwiHLPA+UpG3G9TLQu4WM+VK6sfL7K68AmhcEQ9r+nkj/DvR/GYhYox6twsHUtmWWWIKfcfQQA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-darwin-x64": {
+      "version": "2.4.9",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.4.9.tgz",
+      "integrity": "sha512-LNCLNgqDMG7BLdc3a8aY/dwKPK7+R8/JXJoXjCvZh2gx8KseqBdFDKbhrr7HCWF8SzNhbTaALhTBoh/I6rf9lA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-arm64": {
+      "version": "2.4.9",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.4.9.tgz",
+      "integrity": "sha512-4adnkAUi6K4C/emPRgYznMOcLlUqZdXWM6aIui4VP4LraE764g6Q4YguygnAUoxKjKIXIWPteKMgRbN0wsgwcg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-arm64-musl": {
+      "version": "2.4.9",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.4.9.tgz",
+      "integrity": "sha512-8RCww5xnPn2wpK4L/QDGDOW0dq80uVWfppPxHIUg6mOs9B6gRmqPp32h1Ls3T8GnW8Wo5A8u7vpTwz4fExN+sw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-x64": {
+      "version": "2.4.9",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.4.9.tgz",
+      "integrity": "sha512-L10na7POF0Ks/cgLFNF1ZvIe+X4onLkTi5oP9hY+Rh60Q+7fWzKDDCeGyiHUFf1nGIa9dQOOUPGe2MyYg8nMSQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-x64-musl": {
+      "version": "2.4.9",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.4.9.tgz",
+      "integrity": "sha512-5TD+WS9v5vzXKzjetF0hgoaNFHMcpQeBUwKKVi3JbG1e9UCrFuUK3Gt185fyTzvRdwYkJJEMqglRPjmesmVv4A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-win32-arm64": {
+      "version": "2.4.9",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.4.9.tgz",
+      "integrity": "sha512-aDZr0RBC3sMGJOU10BvG7eZIlWLK/i51HRIfScE2lVhfts2dQTreowLiJJd+UYg/tHKxS470IbzpuKmd0MiD6g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-win32-x64": {
+      "version": "2.4.9",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.4.9.tgz",
+      "integrity": "sha512-NS4g/2G9SoQ4ktKtz31pvyc/rmgzlcIDCGU/zWbmHJAqx6gcRj2gj5Q/guXhoWTzCUaQZDIqiCQXHS7BcGYc0w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
       }
     },
     "node_modules/@emnapi/core": {
@@ -98,353 +273,6 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
-      }
-    },
-    "node_modules/@oxlint/binding-android-arm-eabi": {
-      "version": "1.57.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm-eabi/-/binding-android-arm-eabi-1.57.0.tgz",
-      "integrity": "sha512-C7EiyfAJG4B70496eV543nKiq5cH0o/xIh/ufbjQz3SIvHhlDDsyn+mRFh+aW8KskTyUpyH2LGWL8p2oN6bl1A==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@oxlint/binding-android-arm64": {
-      "version": "1.57.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm64/-/binding-android-arm64-1.57.0.tgz",
-      "integrity": "sha512-9i80AresjZ/FZf5xK8tKFbhQnijD4s1eOZw6/FHUwD59HEZbVLRc2C88ADYJfLZrF5XofWDiRX/Ja9KefCLy7w==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@oxlint/binding-darwin-arm64": {
-      "version": "1.57.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-arm64/-/binding-darwin-arm64-1.57.0.tgz",
-      "integrity": "sha512-0eUfhRz5L2yKa9I8k3qpyl37XK3oBS5BvrgdVIx599WZK63P8sMbg+0s4IuxmIiZuBK68Ek+Z+gcKgeYf0otsg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@oxlint/binding-darwin-x64": {
-      "version": "1.57.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-x64/-/binding-darwin-x64-1.57.0.tgz",
-      "integrity": "sha512-UvrSuzBaYOue+QMAcuDITe0k/Vhj6KZGjfnI6x+NkxBTke/VoM7ZisaxgNY0LWuBkTnd1OmeQfEQdQ48fRjkQg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@oxlint/binding-freebsd-x64": {
-      "version": "1.57.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-freebsd-x64/-/binding-freebsd-x64-1.57.0.tgz",
-      "integrity": "sha512-wtQq0dCoiw4bUwlsNVDJJ3pxJA218fOezpgtLKrbQqUtQJcM9yP8z+I9fu14aHg0uyAxIY+99toL6uBa2r7nxA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@oxlint/binding-linux-arm-gnueabihf": {
-      "version": "1.57.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.57.0.tgz",
-      "integrity": "sha512-qxFWl2BBBFcT4djKa+OtMdnLgoHEJXpqjyGwz8OhW35ImoCwR5qtAGqApNYce5260FQqoAHW8S8eZTjiX67Tsg==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@oxlint/binding-linux-arm-musleabihf": {
-      "version": "1.57.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-1.57.0.tgz",
-      "integrity": "sha512-SQoIsBU7J0bDW15/f0/RvxHfY3Y0+eB/caKBQtNFbuerTiA6JCYx9P1MrrFTwY2dTm/lMgTSgskvCEYk2AtG/Q==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@oxlint/binding-linux-arm64-gnu": {
-      "version": "1.57.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.57.0.tgz",
-      "integrity": "sha512-jqxYd1W6WMeozsCmqe9Rzbu3SRrGTyGDAipRlRggetyYbUksJqJKvUNTQtZR/KFoJPb+grnSm5SHhdWrywv3RQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@oxlint/binding-linux-arm64-musl": {
-      "version": "1.57.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.57.0.tgz",
-      "integrity": "sha512-i66WyEPVEvq9bxRUCJ/MP5EBfnTDN3nhwEdFZFTO5MmLLvzngfWEG3NSdXQzTT3vk5B9i6C2XSIYBh+aG6uqyg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "libc": [
-        "musl"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@oxlint/binding-linux-ppc64-gnu": {
-      "version": "1.57.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.57.0.tgz",
-      "integrity": "sha512-oMZDCwz4NobclZU3pH+V1/upVlJZiZvne4jQP+zhJwt+lmio4XXr4qG47CehvrW1Lx2YZiIHuxM2D4YpkG3KVA==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@oxlint/binding-linux-riscv64-gnu": {
-      "version": "1.57.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-1.57.0.tgz",
-      "integrity": "sha512-uoBnjJ3MMEBbfnWC1jSFr7/nSCkcQYa72NYoNtLl1imshDnWSolYCjzb8LVCwYCCfLJXD+0gBLD7fyC14c0+0g==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@oxlint/binding-linux-riscv64-musl": {
-      "version": "1.57.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-1.57.0.tgz",
-      "integrity": "sha512-BdrwD7haPZ8a9KrZhKJRSj6jwCor+Z8tHFZ3PT89Y3Jq5v3LfMfEePeAmD0LOTWpiTmzSzdmyw9ijneapiVHKQ==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "libc": [
-        "musl"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@oxlint/binding-linux-s390x-gnu": {
-      "version": "1.57.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.57.0.tgz",
-      "integrity": "sha512-BNs+7ZNsRstVg2tpNxAXfMX/Iv5oZh204dVyb8Z37+/gCh+yZqNTlg6YwCLIMPSk5wLWIGOaQjT0GUOahKYImw==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@oxlint/binding-linux-x64-gnu": {
-      "version": "1.57.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.57.0.tgz",
-      "integrity": "sha512-AghS18w+XcENcAX0+BQGLiqjpqpaxKJa4cWWP0OWNLacs27vHBxu7TYkv9LUSGe5w8lOJHeMxcYfZNOAPqw2bg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@oxlint/binding-linux-x64-musl": {
-      "version": "1.57.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-musl/-/binding-linux-x64-musl-1.57.0.tgz",
-      "integrity": "sha512-E/FV3GB8phu/Rpkhz5T96hAiJlGzn91qX5yj5gU754P5cmVGXY1Jw/VSjDSlZBCY3VHjsVLdzgdkJaomEmcNOg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "libc": [
-        "musl"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@oxlint/binding-openharmony-arm64": {
-      "version": "1.57.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-openharmony-arm64/-/binding-openharmony-arm64-1.57.0.tgz",
-      "integrity": "sha512-xvZ2yZt0nUVfU14iuGv3V25jpr9pov5N0Wr28RXnHFxHCRxNDMtYPHV61gGLhN9IlXM96gI4pyYpLSJC5ClLCQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openharmony"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@oxlint/binding-win32-arm64-msvc": {
-      "version": "1.57.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.57.0.tgz",
-      "integrity": "sha512-Z4D8Pd0AyHBKeazhdIXeUUy5sIS3Mo0veOlzlDECg6PhRRKgEsBJCCV1n+keUZtQ04OP+i7+itS3kOykUyNhDg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@oxlint/binding-win32-ia32-msvc": {
-      "version": "1.57.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.57.0.tgz",
-      "integrity": "sha512-StOZ9nFMVKvevicbQfql6Pouu9pgbeQnu60Fvhz2S6yfMaii+wnueLnqQ5I1JPgNF0Syew4voBlAaHD13wH6tw==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@oxlint/binding-win32-x64-msvc": {
-      "version": "1.57.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.57.0.tgz",
-      "integrity": "sha512-6PuxhYgth8TuW0+ABPOIkGdBYw+qYGxgIdXPHSVpiCDm+hqTTWCmC739St1Xni0DJBt8HnSHTG67i1y6gr8qrA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@resvg/resvg-js": {
@@ -1676,51 +1504,6 @@
         "https://opencollective.com/debug"
       ],
       "license": "MIT"
-    },
-    "node_modules/oxlint": {
-      "version": "1.57.0",
-      "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.57.0.tgz",
-      "integrity": "sha512-DGFsuBX5MFZX9yiDdtKjTrYPq45CZ8Fft6qCltJITYZxfwYjVdGf/6wycGYTACloauwIPxUnYhBVeZbHvleGhw==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "oxlint": "bin/oxlint"
-      },
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/Boshen"
-      },
-      "optionalDependencies": {
-        "@oxlint/binding-android-arm-eabi": "1.57.0",
-        "@oxlint/binding-android-arm64": "1.57.0",
-        "@oxlint/binding-darwin-arm64": "1.57.0",
-        "@oxlint/binding-darwin-x64": "1.57.0",
-        "@oxlint/binding-freebsd-x64": "1.57.0",
-        "@oxlint/binding-linux-arm-gnueabihf": "1.57.0",
-        "@oxlint/binding-linux-arm-musleabihf": "1.57.0",
-        "@oxlint/binding-linux-arm64-gnu": "1.57.0",
-        "@oxlint/binding-linux-arm64-musl": "1.57.0",
-        "@oxlint/binding-linux-ppc64-gnu": "1.57.0",
-        "@oxlint/binding-linux-riscv64-gnu": "1.57.0",
-        "@oxlint/binding-linux-riscv64-musl": "1.57.0",
-        "@oxlint/binding-linux-s390x-gnu": "1.57.0",
-        "@oxlint/binding-linux-x64-gnu": "1.57.0",
-        "@oxlint/binding-linux-x64-musl": "1.57.0",
-        "@oxlint/binding-openharmony-arm64": "1.57.0",
-        "@oxlint/binding-win32-arm64-msvc": "1.57.0",
-        "@oxlint/binding-win32-ia32-msvc": "1.57.0",
-        "@oxlint/binding-win32-x64-msvc": "1.57.0"
-      },
-      "peerDependencies": {
-        "oxlint-tsgolint": ">=0.15.0"
-      },
-      "peerDependenciesMeta": {
-        "oxlint-tsgolint": {
-          "optional": true
-        }
-      }
     },
     "node_modules/pathe": {
       "version": "2.0.3",

--- a/package.json
+++ b/package.json
@@ -1,56 +1,57 @@
 {
-  "name": "generate-icons",
-  "version": "0.1.14",
-  "description": "generate icons from single image file",
-  "engines": {
-    "node": ">=22"
-  },
-  "bin": {
-    "generate-icons": "generate-icons"
-  },
-  "files": [
-    "dist",
-    "generate-icons"
-  ],
-  "scripts": {
-    "start": "node ./generate-icons",
-    "prepare": "npm run build",
-    "build": "rm -rf dist/* && tsc",
-    "postversion": "git push && git push --tags",
-    "test": "vitest run",
-    "lint": "oxlint"
-  },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/koizuka/generate-icons.git"
-  },
-  "author": "koizuka",
-  "license": "ISC",
-  "bugs": {
-    "url": "https://github.com/koizuka/generate-icons/issues"
-  },
-  "homepage": "https://github.com/koizuka/generate-icons#readme",
-  "type": "module",
-  "keywords": [
-    "svg",
-    "ico",
-    "png"
-  ],
-  "dependencies": {
-    "@resvg/resvg-js": "^2.6.2",
-    "command-line-args": "^6.0.1",
-    "command-line-usage": "^7.0.4",
-    "png-to-ico": "^3.0.1"
-  },
-  "devDependencies": {
-    "@types/command-line-args": "^5.2.3",
-    "@types/command-line-usage": "^5.0.4",
-    "@types/node": "^25.5.0",
-    "@types/pngjs": "^6.0.5",
-    "image-size": "^2.0.2",
-    "oxlint": "^1.57.0",
-    "pngjs": "^7.0.0",
-    "typescript": "^6.0.2",
-    "vitest": "^4.1.1"
-  }
+	"name": "generate-icons",
+	"version": "0.1.14",
+	"description": "generate icons from single image file",
+	"engines": {
+		"node": ">=22"
+	},
+	"bin": {
+		"generate-icons": "generate-icons"
+	},
+	"files": [
+		"dist",
+		"generate-icons"
+	],
+	"scripts": {
+		"start": "node ./generate-icons",
+		"prepare": "npm run build",
+		"build": "rm -rf dist/* && tsc",
+		"postversion": "git push && git push --tags",
+		"test": "vitest run",
+		"lint": "biome check",
+		"lint:fix": "biome check --write"
+	},
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/koizuka/generate-icons.git"
+	},
+	"author": "koizuka",
+	"license": "ISC",
+	"bugs": {
+		"url": "https://github.com/koizuka/generate-icons/issues"
+	},
+	"homepage": "https://github.com/koizuka/generate-icons#readme",
+	"type": "module",
+	"keywords": [
+		"svg",
+		"ico",
+		"png"
+	],
+	"dependencies": {
+		"@resvg/resvg-js": "^2.6.2",
+		"command-line-args": "^6.0.1",
+		"command-line-usage": "^7.0.4",
+		"png-to-ico": "^3.0.1"
+	},
+	"devDependencies": {
+		"@biomejs/biome": "2.4.9",
+		"@types/command-line-args": "^5.2.3",
+		"@types/command-line-usage": "^5.0.4",
+		"@types/node": "^25.5.0",
+		"@types/pngjs": "^6.0.5",
+		"image-size": "^2.0.2",
+		"pngjs": "^7.0.0",
+		"typescript": "^6.0.2",
+		"vitest": "^4.1.1"
+	}
 }

--- a/src/FatalError.ts
+++ b/src/FatalError.ts
@@ -1,22 +1,20 @@
-
 export class FatalError extends Error {
-  readonly filename?: string;
-  readonly error?: object;
+	readonly filename?: string;
+	readonly error?: object;
 
-  constructor(message: string, { error, filename }: { error?: object; filename?: string; }) {
-    super([
-      filename,
-      message,
-      error && error.toString(),
-    ].join(': '));
+	constructor(
+		message: string,
+		{ error, filename }: { error?: object; filename?: string },
+	) {
+		super([filename, message, error?.toString()].join(": "));
 
-    this.filename = filename;
-    this.error = error;
+		this.filename = filename;
+		this.error = error;
 
-    this.name = 'FatalError';
-  }
+		this.name = "FatalError";
+	}
 
-  toString(): string {
-    return this.message;
-  }
+	toString(): string {
+		return this.message;
+	}
 }

--- a/src/getConverter.test.ts
+++ b/src/getConverter.test.ts
@@ -1,76 +1,81 @@
 import sizeOf from "image-size";
 import { PNG } from "pngjs";
 import { getConverter } from "./getConverter.js";
-import { Icon } from "./loadIconsFromManifestJson.js";
+import type { Icon } from "./loadIconsFromManifestJson.js";
 
+describe("generateIconsFromSvgFile", () => {
+	const testSvgFile = "test-data/test.svg";
 
-describe('generateIconsFromSvgFile', () => {
-  const testSvgFile = 'test-data/test.svg';
+	test("unknown", () => {
+		const unknownDef: Icon = {
+			src: "test.unknown",
+			sizes: [{ width: 48, height: 48 }],
+			type: "image/unknown",
+		};
+		expect(getConverter(unknownDef.type)).toBeUndefined();
+	});
 
-  test('unknown', () => {
-    const unknownDef: Icon = {
-      src: "test.unknown",
-      sizes: [{ width: 48, height: 48 }],
-      type: "image/unknown"
-    }
-    expect(getConverter(unknownDef.type)).toBeUndefined();
-  });
+	test("ico", async () => {
+		const icoDef: Icon = {
+			src: "test.ico",
+			sizes: [
+				{ width: 24, height: 24 },
+				{ width: 48, height: 48 },
+				{ width: 96, height: 96 },
+			],
+			type: "image/x-icon",
+		};
+		const convertToIco = getConverter(icoDef.type);
+		expect(convertToIco).not.toBeUndefined();
+		if (convertToIco) {
+			const buffer = await convertToIco(testSvgFile, icoDef.sizes, {});
+			expect(buffer).not.toBeNull();
+			if (buffer) {
+				const size = sizeOf(buffer);
+				expect(size.images).toEqual(icoDef.sizes);
+			}
+		}
+	}, 10000);
 
-  test('ico', async () => {
-    const icoDef: Icon = {
-      src: "test.ico",
-      sizes: [{ width: 24, height: 24 }, { width: 48, height: 48 }, { width: 96, height: 96 }],
-      type: "image/x-icon"
-    };
-    const convertToIco = getConverter(icoDef.type);
-    expect(convertToIco).not.toBeUndefined();
-    if (convertToIco) {
-      const buffer = await convertToIco(testSvgFile, icoDef.sizes, {});
-      expect(buffer).not.toBeNull();
-      if (buffer) {
-        const size = sizeOf(buffer);
-        expect(size.images).toEqual(icoDef.sizes);
-      }
-    }
-  }, 10000);
+	test("png", async () => {
+		const pngDef: Icon = {
+			src: "test.png",
+			sizes: [{ width: 48, height: 48 }],
+			type: "image/png",
+		};
+		const convertToPng = getConverter(pngDef.type);
+		expect(convertToPng).not.toBeUndefined();
+		if (convertToPng) {
+			const buffer = await convertToPng(testSvgFile, pngDef.sizes, {});
+			expect(buffer).not.toBeNull();
+			if (buffer) {
+				const png = PNG.sync.read(buffer);
 
-  test('png', async () => {
-    const pngDef: Icon = {
-      src: "test.png",
-      sizes: [{ width: 48, height: 48 }],
-      type: "image/png"
-    };
-    const convertToPng = getConverter(pngDef.type);
-    expect(convertToPng).not.toBeUndefined();
-    if (convertToPng) {
-      const buffer = await convertToPng(testSvgFile, pngDef.sizes, {});
-      expect(buffer).not.toBeNull();
-      if (buffer) {
-        const png = PNG.sync.read(buffer);
+				expect({ width: png.width, height: png.height }).toEqual({
+					width: 48,
+					height: 48,
+				});
 
-        expect({ width: png.width, height: png.height }).toEqual({ width: 48, height: 48 });
+				const get = (x: number, y: number) => {
+					const start = (x + y * png.width) * 4;
+					return png.data.slice(start, start + 4);
+				};
 
-        const get = (x: number, y: number) => {
-          const start = (x + y * png.width) * 4;
-          return png.data.slice(start, start + 4);
-        }
+				const red = [255, 0, 0, 255];
+				const blue = [0, 0, 255, 255];
+				const white = [255, 255, 255, 255];
+				const magenta = [255, 0, 255, 255];
+				const cyan = [0, 255, 255, 255];
+				const transparent = [0, 0, 0, 0];
 
-        const red = [255, 0, 0, 255];
-        const blue = [0, 0, 255, 255];
-        const white = [255, 255, 255, 255];
-        const magenta = [255, 0, 255, 255];
-        const cyan = [0, 255, 255, 255];
-        const transparent = [0, 0, 0, 0];
-
-        expect(get(0, 0)).toEqual(Buffer.from(red));
-        expect(get(47, 0)).toEqual(Buffer.from(blue));
-        expect(get(0, 24)).toEqual(Buffer.from(transparent));
-        expect(get(24, 24)).toEqual(Buffer.from(white));
-        expect(get(47, 24)).toEqual(Buffer.from(transparent));
-        expect(get(0, 47)).toEqual(Buffer.from(magenta));
-        expect(get(47, 47)).toEqual(Buffer.from(cyan));
-      }
-    }
-  });
-
+				expect(get(0, 0)).toEqual(Buffer.from(red));
+				expect(get(47, 0)).toEqual(Buffer.from(blue));
+				expect(get(0, 24)).toEqual(Buffer.from(transparent));
+				expect(get(24, 24)).toEqual(Buffer.from(white));
+				expect(get(47, 24)).toEqual(Buffer.from(transparent));
+				expect(get(0, 47)).toEqual(Buffer.from(magenta));
+				expect(get(47, 47)).toEqual(Buffer.from(cyan));
+			}
+		}
+	});
 });

--- a/src/getConverter.ts
+++ b/src/getConverter.ts
@@ -1,53 +1,72 @@
-import { readFileSync } from 'fs';
-import { renderAsync } from '@resvg/resvg-js';
-import { FatalError } from './FatalError.js';
-import { Size } from './loadIconsFromManifestJson.js';
+import { readFileSync } from "node:fs";
+import { renderAsync } from "@resvg/resvg-js";
+import { FatalError } from "./FatalError.js";
+import type { Size } from "./loadIconsFromManifestJson.js";
 
-async function getPngFromSvgFile(filename: string, { size, background }: { size: { width: number, height: number }, background?: string }): Promise<Buffer> {
-  try {
-    const svg = readFileSync(filename, 'utf-8');
-    const result = await renderAsync(svg, {
-      fitTo: { mode: 'width', value: size.width },
-      background,
-      font: { loadSystemFonts: true },
-    });
-    return result.asPng();
-  }
-  catch (err: unknown) {
-    const error = err as Error;
-    throw new FatalError(`failed loading SVG file`, { filename, error });
-  }
+async function getPngFromSvgFile(
+	filename: string,
+	{
+		size,
+		background,
+	}: { size: { width: number; height: number }; background?: string },
+): Promise<Buffer> {
+	try {
+		const svg = readFileSync(filename, "utf-8");
+		const result = await renderAsync(svg, {
+			fitTo: { mode: "width", value: size.width },
+			background,
+			font: { loadSystemFonts: true },
+		});
+		return result.asPng();
+	} catch (err: unknown) {
+		const error = err as Error;
+		throw new FatalError(`failed loading SVG file`, { filename, error });
+	}
 }
 
 export type GenerateIconOptions = {
-  background?: string;
-  log?: (...message: any[]) => void,
+	background?: string;
+	log?: (...message: unknown[]) => void;
+};
+
+async function svgToIco(
+	svgFilename: string,
+	sizes: Size[],
+	{ background, log }: GenerateIconOptions,
+): Promise<Buffer> {
+	const pngs = await Promise.all(
+		sizes.map((size) => {
+			log?.("size:", size.width);
+			return getPngFromSvgFile(svgFilename, { size, background });
+		}),
+	);
+	const { default: PngToIco } = await import("png-to-ico");
+	return await PngToIco(pngs);
 }
 
-async function svgToIco(svgFilename: string, sizes: Size[], { background, log }: GenerateIconOptions): Promise<Buffer> {
-  const pngs = await Promise.all(sizes.map(size => {
-    log?.('size:', size.width);
-    return getPngFromSvgFile(svgFilename, { size, background });
-  }));
-  const { default: PngToIco } = await import('png-to-ico');
-  return await PngToIco(pngs);
+async function svgToPng(
+	svgFilename: string,
+	sizes: Size[],
+	{ background, log }: GenerateIconOptions,
+): Promise<Buffer> {
+	if (sizes.length !== 1) {
+		throw Error(`PNG: number of sizes must be 1, but ${sizes.length}`);
+	}
+	log?.("size:", sizes[0].width);
+	return await getPngFromSvgFile(svgFilename, { size: sizes[0], background });
 }
 
-async function svgToPng(svgFilename: string, sizes: Size[], { background, log }: GenerateIconOptions): Promise<Buffer> {
-  if (sizes.length !== 1) {
-    throw Error(`PNG: number of sizes must be 1, but ${sizes.length}`)
-  }
-  log?.('size:', sizes[0].width);
-  return await getPngFromSvgFile(svgFilename, { size: sizes[0], background });
-}
-
-type Converter = (svgFilename: string, sizes: Size[], { background, log }: GenerateIconOptions) => Promise<Buffer>;
+type Converter = (
+	svgFilename: string,
+	sizes: Size[],
+	{ background, log }: GenerateIconOptions,
+) => Promise<Buffer>;
 
 const converters: { [type: string]: Converter } = {
-  'image/x-icon': svgToIco,
-  'image/png': svgToPng,
+	"image/x-icon": svgToIco,
+	"image/png": svgToPng,
 };
 
 export function getConverter(type: string): Converter | undefined {
-  return converters[type];
+	return converters[type];
 }

--- a/src/loadIconsFromManifestJson.test.ts
+++ b/src/loadIconsFromManifestJson.test.ts
@@ -1,15 +1,19 @@
-import { parseIconSizes } from "./loadIconsFromManifestJson.js"
+import { parseIconSizes } from "./loadIconsFromManifestJson.js";
 
-describe('parseIconSizes', () => {
-  test('single size', () => {
-    expect(parseIconSizes("24x24")).toEqual([{ width: 24, height: 24 }]);
-  });
+describe("parseIconSizes", () => {
+	test("single size", () => {
+		expect(parseIconSizes("24x24")).toEqual([{ width: 24, height: 24 }]);
+	});
 
-  test('multiple sizes', () => {
-    expect(parseIconSizes("24x24 48x48 96x96")).toEqual([{ width: 24, height: 24 }, { width: 48, height: 48 }, { width: 96, height: 96 }]);
-  });
+	test("multiple sizes", () => {
+		expect(parseIconSizes("24x24 48x48 96x96")).toEqual([
+			{ width: 24, height: 24 },
+			{ width: 48, height: 48 },
+			{ width: 96, height: 96 },
+		]);
+	});
 
-  test('invalid size', () => {
-    expect(() => parseIconSizes("test")).toThrow("invalid size: 'test'");
-  });
-})
+	test("invalid size", () => {
+		expect(() => parseIconSizes("test")).toThrow("invalid size: 'test'");
+	});
+});

--- a/src/loadIconsFromManifestJson.ts
+++ b/src/loadIconsFromManifestJson.ts
@@ -1,78 +1,84 @@
-import { readFile } from 'fs/promises';
+import { readFile } from "node:fs/promises";
 import { FatalError } from "./FatalError.js";
 
 type IconField = {
-  src: string; // eg. "favicon.ico"
-  sizes: string; // eg. "256x256 48x48"
-  type: string; // MIME type. eg. "image/x-icon" "image/png"
-}
+	src: string; // eg. "favicon.ico"
+	sizes: string; // eg. "256x256 48x48"
+	type: string; // MIME type. eg. "image/x-icon" "image/png"
+};
 
 function isIconField(obj: object): obj is IconField {
-  return ('src' in obj)
-    && ('sizes' in obj)
-    && ('type' in obj);
+	return "src" in obj && "sizes" in obj && "type" in obj;
 }
 
 export type Size = {
-  width: number;
-  height: number;
-}
+	width: number;
+	height: number;
+};
 
 export type Icon = {
-  src: string; // eg. "favicon.ico"
-  sizes: Size[];
-  type: string; // MIME type. eg. "image/x-icon" "image/png"
-}
+	src: string; // eg. "favicon.ico"
+	sizes: Size[];
+	type: string; // MIME type. eg. "image/x-icon" "image/png"
+};
 
 export function parseIconSizes(sizes: string): Size[] {
-  return sizes.split(' ').map(s => {
-    const m = s.match(/(\d+)x(\d+)/);
-    if (!m || m.length < 3) {
-      throw new Error(`invalid size: '${s}'`);
-    }
-    const width = parseInt(m[1], 10);
-    const height = parseInt(m[2], 10);
-    if (width !== height) {
-      throw new Error(`invalid size: '${s}' (width: ${width}, height: ${height}). width must be equal to height.`);
-    }
-    if (width < 8) {
-      throw new Error(`size too small: '${s}' (${width}).`);
-    }
-    return {
-      width,
-      height,
-    };
-  });
+	return sizes.split(" ").map((s) => {
+		const m = s.match(/(\d+)x(\d+)/);
+		if (!m || m.length < 3) {
+			throw new Error(`invalid size: '${s}'`);
+		}
+		const width = parseInt(m[1], 10);
+		const height = parseInt(m[2], 10);
+		if (width !== height) {
+			throw new Error(
+				`invalid size: '${s}' (width: ${width}, height: ${height}). width must be equal to height.`,
+			);
+		}
+		if (width < 8) {
+			throw new Error(`size too small: '${s}' (${width}).`);
+		}
+		return {
+			width,
+			height,
+		};
+	});
 }
 
 function iconFieldToIcon(iconField: IconField): Icon {
-  try {
-    return {
-      ...iconField,
-      sizes: parseIconSizes(iconField.sizes),
-    }
-  } catch (e: any) {
-    throw new FatalError(`${iconField.src}: ${e.message}}`, {});
-  }
+	try {
+		return {
+			...iconField,
+			sizes: parseIconSizes(iconField.sizes),
+		};
+	} catch (e: unknown) {
+		const error = e instanceof Error ? e.message : String(e);
+		throw new FatalError(`${iconField.src}: ${error}}`, {});
+	}
 }
 
-export async function loadIconsFromManifestJson(filename: string): Promise<Icon[]> {
-  try {
-    const manifestJson = await readFile(filename);
-    const manifest = JSON.parse(manifestJson.toString('utf8'));
-    if (!('icons' in manifest) || !Array.isArray(manifest.icons)) {
-      throw new Error(`there is no 'icons' array field. is this correct manifest.json file?`);
-    }
-    const icons = manifest.icons as IconField[];
-    for (const icon of icons) {
-      if (!isIconField(icon)) {
-        throw new Error('invalid icons[] field. is this correct manifest.json file?');
-      }
-    }
-    return icons.map(field => iconFieldToIcon(field));
-  }
-  catch (err: unknown) {
-    const error = err as Error;
-    throw new FatalError(`loading manifest.json failed`, { filename, error });
-  }
+export async function loadIconsFromManifestJson(
+	filename: string,
+): Promise<Icon[]> {
+	try {
+		const manifestJson = await readFile(filename);
+		const manifest = JSON.parse(manifestJson.toString("utf8"));
+		if (!("icons" in manifest) || !Array.isArray(manifest.icons)) {
+			throw new Error(
+				`there is no 'icons' array field. is this correct manifest.json file?`,
+			);
+		}
+		const icons = manifest.icons as IconField[];
+		for (const icon of icons) {
+			if (!isIconField(icon)) {
+				throw new Error(
+					"invalid icons[] field. is this correct manifest.json file?",
+				);
+			}
+		}
+		return icons.map((field) => iconFieldToIcon(field));
+	} catch (err: unknown) {
+		const error = err as Error;
+		throw new FatalError(`loading manifest.json failed`, { filename, error });
+	}
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,154 +1,157 @@
-import commandLineArgs from 'command-line-args';
-import commandLineUsage from 'command-line-usage';
-import { readFileSync, writeFileSync } from 'fs';
-import path from 'path';
-import { fileURLToPath } from 'url';
+import { readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import commandLineArgs from "command-line-args";
+import commandLineUsage from "command-line-usage";
 import { FatalError } from "./FatalError.js";
-import { getConverter } from './getConverter.js';
+import { getConverter } from "./getConverter.js";
 import { loadIconsFromManifestJson } from "./loadIconsFromManifestJson.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export function getVersion() {
-  const packageJson = readFileSync(path.join(__dirname, '..', 'package.json'));
-  try {
-    const pkg = JSON.parse(packageJson.toString('utf8'));
-    return pkg.version;
-  }
-  catch (err: unknown) {
-    const error = err as Error;
-    throw new FatalError(`reading '${packageJson}' failed`, { error });
-  }
+	const packageJson = readFileSync(path.join(__dirname, "..", "package.json"));
+	try {
+		const pkg = JSON.parse(packageJson.toString("utf8"));
+		return pkg.version;
+	} catch (err: unknown) {
+		const error = err as Error;
+		throw new FatalError(`reading '${packageJson}' failed`, { error });
+	}
 }
 
 async function main() {
-  // parse command line
-  const optionDefinitions: commandLineUsage.OptionDefinition[] = [
-    {
-      name: 'help',
-      alias: 'h',
-      type: Boolean,
-      description: 'Show this help.'
-    },
-    {
-      name: 'version',
-      alias: 'v',
-      type: Boolean,
-      description: 'Show version.'
-    },
-    {
-      name: 'manifest',
-      alias: 'm',
-      type: String,
-      defaultValue: './public/manifest.json',
-      description: 'Specify manifest.json file.',
-    },
-    {
-      name: 'src',
-      defaultOption: true,
-      type: String,
-      description: 'SVG filename to read.'
-    },
-    {
-      name: 'background',
-      type: String,
-      description: 'Background color(eg. "white", "#ffffff"). transparent if not specified.',
-    },
-  ];
+	// parse command line
+	const optionDefinitions: commandLineUsage.OptionDefinition[] = [
+		{
+			name: "help",
+			alias: "h",
+			type: Boolean,
+			description: "Show this help.",
+		},
+		{
+			name: "version",
+			alias: "v",
+			type: Boolean,
+			description: "Show version.",
+		},
+		{
+			name: "manifest",
+			alias: "m",
+			type: String,
+			defaultValue: "./public/manifest.json",
+			description: "Specify manifest.json file.",
+		},
+		{
+			name: "src",
+			defaultOption: true,
+			type: String,
+			description: "SVG filename to read.",
+		},
+		{
+			name: "background",
+			type: String,
+			description:
+				'Background color(eg. "white", "#ffffff"). transparent if not specified.',
+		},
+	];
 
-  type Options = {
-    help: boolean;
-    version: boolean;
-    manifest: string;
-    src: string;
-    background?: string;
-  };
+	type Options = {
+		help: boolean;
+		version: boolean;
+		manifest: string;
+		src: string;
+		background?: string;
+	};
 
-  const options = function (): Options {
-    try {
-      return commandLineArgs(optionDefinitions) as Options;
-    }
-    catch (err: unknown) {
-      const e = err as Error
-      console.error(`command line error: ${e.message}`);
-      process.exit(1);
-    }
-  }();
+	const options = ((): Options => {
+		try {
+			return commandLineArgs(optionDefinitions) as Options;
+		} catch (err: unknown) {
+			const e = err as Error;
+			console.error(`command line error: ${e.message}`);
+			process.exit(1);
+		}
+	})();
 
-  if (options.version) {
-    console.log(getVersion());
-    return;
-  }
+	if (options.version) {
+		console.log(getVersion());
+		return;
+	}
 
-  if (!options.help) {
-    if (!options.src) {
-      console.error('an SVG filename is required!');
-      process.exitCode = 1;
-      options.help = true;
-    }
-  }
+	if (!options.help) {
+		if (!options.src) {
+			console.error("an SVG filename is required!");
+			process.exitCode = 1;
+			options.help = true;
+		}
+	}
 
-  if (options.help) {
-    const usage = commandLineUsage([
-      {
-        header: `generate-icons ${getVersion()}`,
-        content: 'generate icon files defined in manifest.json from a SVG file.',
-      },
-      {
-        header: 'Options',
-        optionList: optionDefinitions,
-      },
-      {
-        content: 'Project home: {underline https://github.com/koizuka/generate-icons}',
-      },
-    ]);
-    console.log(usage);
-    return;
-  }
+	if (options.help) {
+		const usage = commandLineUsage([
+			{
+				header: `generate-icons ${getVersion()}`,
+				content:
+					"generate icon files defined in manifest.json from a SVG file.",
+			},
+			{
+				header: "Options",
+				optionList: optionDefinitions,
+			},
+			{
+				content:
+					"Project home: {underline https://github.com/koizuka/generate-icons}",
+			},
+		]);
+		console.log(usage);
+		return;
+	}
 
-  const log = (...args: any[]) => console.log(...args);
+	const log = (...args: unknown[]) => console.log(...args);
 
-  const svgFilename = options.src;
-  log(`Input SVG file: ${svgFilename}`);
+	const svgFilename = options.src;
+	log(`Input SVG file: ${svgFilename}`);
 
-  // read manifest.json
-  try {
-    const manifestFilename = options.manifest;
-    const dirname = path.dirname(manifestFilename);
+	// read manifest.json
+	try {
+		const manifestFilename = options.manifest;
+		const dirname = path.dirname(manifestFilename);
 
-    const icons = await loadIconsFromManifestJson(manifestFilename);
-    for (const icon of icons) {
-      const filename = path.join(dirname, icon.src);
-      log(`${filename}: type: ${icon.type}`);
-      const convert = getConverter(icon.type);
-      if (!convert) {
-        log(`Unsupported type '${icon.type}'. ignored.`);
-        continue;
-      }
+		const icons = await loadIconsFromManifestJson(manifestFilename);
+		for (const icon of icons) {
+			const filename = path.join(dirname, icon.src);
+			log(`${filename}: type: ${icon.type}`);
+			const convert = getConverter(icon.type);
+			if (!convert) {
+				log(`Unsupported type '${icon.type}'. ignored.`);
+				continue;
+			}
 
-      let buffer: Buffer;
-      try {
-        buffer = await convert(svgFilename, icon.sizes, {
-          background: options.background,
-          log,
-        });
-      } catch (err) {
-        const error = err as Error;
-        throw new FatalError(`failed to convert`, { filename: icon.src, error });
-      }
+			let buffer: Buffer;
+			try {
+				buffer = await convert(svgFilename, icon.sizes, {
+					background: options.background,
+					log,
+				});
+			} catch (err) {
+				const error = err as Error;
+				throw new FatalError(`failed to convert`, {
+					filename: icon.src,
+					error,
+				});
+			}
 
-      try {
-        writeFileSync(filename, buffer);
-      } catch (err: unknown) {
-        const error = err as Error;
-        throw new FatalError(`failed to write`, { filename, error });
-      }
-    }
-  } catch (err: unknown) {
-    console.error(err);
-    process.exit(1);
-  }
+			try {
+				writeFileSync(filename, buffer);
+			} catch (err: unknown) {
+				const error = err as Error;
+				throw new FatalError(`failed to write`, { filename, error });
+			}
+		}
+	} catch (err: unknown) {
+		console.error(err);
+		process.exit(1);
+	}
 }
 
 main();
-

--- a/test-data/manifest.json
+++ b/test-data/manifest.json
@@ -1,14 +1,14 @@
 {
-  "icons": [
-    {
-      "src": "test.ico",
-      "sizes": "24x24 48x48 96x96",
-      "type": "image/x-icon"
-    },
-    {
-      "src": "test.png",
-      "sizes": "48x48",
-      "type": "image/png"
-    }
-  ]
+	"icons": [
+		{
+			"src": "test.ico",
+			"sizes": "24x24 48x48 96x96",
+			"type": "image/x-icon"
+		},
+		{
+			"src": "test.png",
+			"sizes": "48x48",
+			"type": "image/png"
+		}
+	]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,15 +1,15 @@
 {
-  "include": ["src/**/*.ts", "test/**/*.ts"],
-  "exclude": ["node_modules", "**/*.test.ts"],
-  "compilerOptions": {
-    "target": "ES2022",
-    "module": "nodenext",
-    "moduleResolution": "nodenext",
-    "outDir": "./dist",
-    "rootDir": "./src",
-    "types": ["vitest/globals"],
-    "strict": true,
-    "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true
-  }
+	"include": ["src/**/*.ts", "test/**/*.ts"],
+	"exclude": ["node_modules", "**/*.test.ts"],
+	"compilerOptions": {
+		"target": "ES2022",
+		"module": "nodenext",
+		"moduleResolution": "nodenext",
+		"outDir": "./dist",
+		"rootDir": "./src",
+		"types": ["vitest/globals"],
+		"strict": true,
+		"skipLibCheck": true,
+		"forceConsistentCasingInFileNames": true
+	}
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,8 +1,8 @@
-import { defineConfig } from 'vitest/config';
+import { defineConfig } from "vitest/config";
 
 export default defineConfig({
-  test: {
-    globals: true,
-    include: ['**/*.test.ts'],
-  },
+	test: {
+		globals: true,
+		include: ["**/*.test.ts"],
+	},
 });


### PR DESCRIPTION
## Summary
- Replace oxlint with Biome (linter + formatter in one tool)
- Apply Biome formatting across all files (tabs, double quotes, trailing commas)
- Add `node:` protocol to Node.js builtin imports
- Use `import type` for type-only imports
- Replace `any` with `unknown` for stricter type safety
- Use optional chaining in FatalError
- VS Code: format on save + auto-fix with Biome extension

## Test plan
- [x] `npm run lint` (`biome check`) reports 0 issues
- [x] `npm test` passes
- [x] `npm run build` succeeds
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)