### PR TITLE
ci(dependabot): add cooldown period to reduce update noise

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,12 @@ updates:
   schedule:
     interval: daily
   open-pull-requests-limit: 10
+  cooldown:
+    default-days: 7
 - package-ecosystem: "github-actions"
   directory: "/"
   schedule:
     # Check for updates to GitHub Actions every week
     interval: "weekly"
+  cooldown:
+    default-days: 7


### PR DESCRIPTION
## Summary
- Dependabot設定に各エコシステムへcooldownを追加（デフォルト7日間）
- 依存関係更新PRの頻度を抑え、更新ノイズを削減

🤖 Generated with [Claude Code](https://claude.com/claude-code)